### PR TITLE
生成されるcsvの名前を修正

### DIFF
--- a/ruby_scripts/deploy.rb
+++ b/ruby_scripts/deploy.rb
@@ -18,7 +18,7 @@ class CoderDojoSakuraCLI
   require './ruby_scripts/sakura_server_user_agent.rb'
   require 'csv'
   INSTANCE_CSV = "servers.csv".freeze
-  RESULT_INSTANCE_CSV = "instance.csv".freeze
+  RESULT_INSTANCE_CSV = "instances.csv".freeze
 
   #jsではproductionの方を特別にしていたが、たぶんprodocutionの方を頻繁に叩くので...
   def initialize(argv)


### PR DESCRIPTION
現在のciでは、サーバーの生成後、現在の状況をまとめた instances.csvを自動生成している。
しかしrubyへの移植時に、typoして `instance.csv` を生成するようにしてしまったので、修正した。