### PR TITLE
Update ToS for DojoPaaS users:

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ CoderDojo `ooo` (代表: `ooo`) は、以下の各項目に同意した上で、
    - ディスク: 20GB
 4. さくらインターネットのバナー画像または文言を、当該 CoderDojo の公式Webサイトに掲載します
    - バナー画像を使用する際は、[さくらインターネットのブランドアセット](https://www.sakura.ad.jp/brand-assets/)のガイドラインに従います
-5. さくらインターネットから活動実績報告のお願いが来た際、可能な範囲で協力します
+5. [さくらインターネット × CoderDojo](https://www.facebook.com/groups/sakura.coderdojo/) の合同グループに参加し、活動実績報告などのお願いが来た際、可能な範囲で協力します
 6. 利用する CoderDojo は、[coderdojo.jp](https://coderdojo.jp/#dojos) に掲載されていることを確認しました
 7. さくらインターネットまたは CoderDojo Japan の都合により、事前の通達を持って、サーバーの提供が中止になる可能性があることを承諾します
 8. 提供されたサーバーは CoderDojo のために使い、他の用途で使う場合は、一般社団法人 CoderDojo Japan からの書面による許諾を事前に得ます


### PR DESCRIPTION
This will be merged and published at the day of this event: https://sakura-tokyo.connpass.com/event/345669/

```diff
- 5. さくらインターネットから活動実績報告のお願いが来た際、可能な範囲で協力します
+ 5. [さくらインターネット × CoderDojo](https://www.facebook.com/groups/sakura.coderdojo/) の合同グループに参加し、活動実績報告などのお願いが来た際、可能な範囲で協力します
```

変更理由まとめ:

1. 「さくらインターネットから活動実績報告のお願い」の **具体的な受け取り方法が不明瞭** でした 💦 
2. [さくらインターネット × CoderDojo](https://www.facebook.com/groups/sakura.coderdojo/) の合同グループを作成し、 **関係各者とサーバー利用者 (Champion/Mentorなど) との連携が取り易い状況** を作りました 🤝
3. 上記の変更箇所および変更理由をまとめ、 **以下の合同イベント開催日にて本件も合わせて周知および本 PR をマージ** します 📢 

さくらの夕べ CoderDojoナイト @ 2025/03/05 - connpass
https://sakura-tokyo.connpass.com/event/345669/