### PR TITLE
Fix: CI テスト実行時の環境変数エラーを修正

### DIFF
--- a/scripts/sakura_server_user_agent.rb
+++ b/scripts/sakura_server_user_agent.rb
@@ -11,8 +11,8 @@ class SakuraServerUserAgent
   SAKURA_CLOUD_SUFFIX = 'api/cloud'
   SAKURA_API_VERSION  = '1.1'
 
-  SAKURA_TOKEN        = ENV.fetch('SACLOUD_ACCESS_TOKEN')
-  SAKURA_TOKEN_SECRET = ENV.fetch('SACLOUD_ACCESS_TOKEN_SECRET')
+  SAKURA_TOKEN        = ENV.fetch('SACLOUD_ACCESS_TOKEN', 'dummy-token-for-test')
+  SAKURA_TOKEN_SECRET = ENV.fetch('SACLOUD_ACCESS_TOKEN_SECRET', 'dummy-secret-for-test')
   
   # ディスク状態確認用の定数
   DISK_CHECK_INTERVAL = 10  # 秒


### PR DESCRIPTION
## 概要
CI でのテスト実行時に環境変数が見つからずエラーになる問題を修正しました。

## 問題
- `bundle exec rake test` 実行時に `ENV.fetch('SACLOUD_ACCESS_TOKEN')` で KeyError が発生
- 外部からの PR では GitHub Secrets にアクセスできないため、環境変数が設定できない
- エラーログ: https://github.com/coderdojo-japan/dojopaas/actions/runs/17454288642/job/49564716126

<img width="578" height="618" alt="image" src="https://github.com/user-attachments/assets/afbef599-f635-404b-ac83-d90df49076e0" />

## 解決策
`ENV.fetch` の第2引数にデフォルト値を設定することで、環境変数がない場合でもテストが実行可能になります。

```ruby
# Before
ENV.fetch('SACLOUD_ACCESS_TOKEN')  # 環境変数がないと KeyError

# After  
ENV.fetch('SACLOUD_ACCESS_TOKEN', 'dummy-token-for-test')  # なければダミー値
```

## なぜこの解決策が優れているか

1. **最小限の変更**: コードの2行のみ修正（GitHub Actions の変更不要）
2. **安全性維持**: 
   - 本番環境では実際のトークンを使用
   - テスト環境ではダミー値で動作
   - API呼び出し時に無効なトークンならエラー（正しい動作）
3. **Ruby らしい実装**: `ENV.fetch` の標準機能を活用

## なぜダミートークンで動作するか

現在のテスト（`ip_validation_test.rb`）は：
- クラスメソッドのみをテスト（IP アドレス検証ロジック）
- API 通信は行わない
- インスタンス作成もしない

そのため、`ENV.fetch` を満足させる値があれば十分です。実際の API 操作時には適切な認証エラーが発生するため、セキュリティ上の問題はありません。

## テスト結果
```
9 runs, 1350 assertions, 0 failures, 0 errors, 0 skips
```

## 変更内容
- `scripts/sakura_server_user_agent.rb`: ENV.fetch にデフォルト値を追加（2行）