### PR TITLE
feat: デプロイ時のコミットメッセージに PR番号を自動追加

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,5 +10,22 @@ git config user.email "yohei@yasslab.jp"
 git add -f README.md
 git add -f instances.csv
 
-git commit --quiet -m    "Deploy from actions"
+# マージコミットメッセージから PR番号を抽出
+PR_NUMBER=$(git log -1 --pretty=%B | grep -oE '#[0-9]+' | head -1 || echo "")
+
+# コミットメッセージを動的に生成
+if [ -n "$PR_NUMBER" ]; then
+    COMMIT_MSG="Deploy from actions (PR $PR_NUMBER)"
+else
+    COMMIT_MSG="Deploy from actions"
+fi
+
+# 追加されたサーバー情報を取得（オプション）
+NEW_SERVERS=$(git diff --cached instances.csv | grep '^+' | grep -v '^+++' | cut -d',' -f1 | sed 's/^+//' | head -3 | paste -sd ', ' || echo "")
+
+if [ -n "$NEW_SERVERS" ]; then
+    COMMIT_MSG="$COMMIT_MSG - Added: $NEW_SERVERS"
+fi
+
+git commit --quiet -m    "$COMMIT_MSG"
 git push --force --quiet "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" master:gh-pages


### PR DESCRIPTION
## 概要
GitHub Actions でデプロイする際のコミットメッセージに PR番号を自動的に含めるようにしました。

## 背景
現在、PRがマージされてサーバーが作成された後、手動でコメント「無事生成されました」を追加する必要がありました。

- 例: 
  - https://github.com/coderdojo-japan/dojopaas/pull/256#issuecomment-3252051277

   > こちら無事生成されましたので、後ほどご確認いただけると幸いです！(＞人＜ )✨
   > 1aeb3e9

## 解決策
`bin/deploy.sh` を改修して：
1. マージコミットメッセージから PR番号を自動抽出
2. デプロイコミットに PR番号を含める
3. （オプション）追加されたサーバー名も表示

## 実装の詳細

### Before
```
Deploy from actions
```

### After
```
Deploy from actions (PR #256) - Added: coderdojo-odawara
```

## メリット
1. **PR送信者の追跡が容易**
   - GitHub が PR番号を自動的にリンク化
   - PR ページから instances.csv の更新が確認可能

2. **手動作業の削減**
   - 「無事生成されました」コメントが不要に
   - PR と デプロイコミットが自動的に関連付け

3. **透明性の向上**
   - どの PR でどのサーバーが作成されたか明確

## テスト方法
1. この PR をマージ
2. gh-pages ブランチのコミットメッセージを確認
3. PR番号が含まれていることを確認

## 技術的な詳細
- `git log -1 --pretty=%B` でマージコミットメッセージを取得
- 正規表現 `#[0-9]+` で PR番号を抽出
- `git diff --cached` で追加されたサーバー情報を取得

## 影響範囲
- デプロイスクリプトのみの変更
- 後方互換性あり（PR番号がない場合は従来通り）