### PR TITLE
feat: 個別サーバー作成用のRakeタスクとコミットメッセージの改善

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -367,6 +367,113 @@ namespace :server do
       abort "❌ エラー: #{e.message}"
     end
   end
+
+  # ========================================
+  # 個別サーバー作成タスク（テスト用）
+  # ========================================
+  desc "指定したサーバーを個別に作成（テスト用）"
+  task :create, [:server_name] => [:check_api_credentials] do |t, args|
+    server_name = args[:server_name]
+    
+    unless server_name
+      abort "❌ エラー: サーバー名が必要です\n" \
+            "使い方: rake server:create[coderdojo-japan]\n" \
+            "注意: servers.csvに登録されているサーバー名を指定してください"
+    end
+    
+    puts "="*60
+    puts "🚀 DojoPaaS 個別サーバー作成"
+    puts "="*60
+    puts ""
+    puts "サーバー名: #{server_name}"
+    puts ""
+    
+    # deploy.rbのCoderDojoSakuraCLIクラスを使用（DRY原則）
+    require_relative 'scripts/deploy'
+    
+    cli = CoderDojoSakuraCLI.new([])
+    success = cli.create_single_server(server_name)
+    
+    if success
+      puts ""
+      puts "="*60
+      puts "✅ サーバー作成プロセス完了"
+      puts "="*60
+      puts ""
+      puts "【次のステップ】"
+      puts "1. SSHで接続確認:"
+      puts "   ssh ubuntu@<IPアドレス>"
+      puts ""
+      puts "2. スタートアップスクリプトの実行状況確認:"
+      puts "   ssh ubuntu@<IPアドレス> 'sudo tail -f /var/log/cloud-init-output.log'"
+      puts ""
+    else
+      puts ""
+      puts "="*60
+      puts "❌ サーバー作成に失敗しました"
+      puts "="*60
+      exit 1
+    end
+  end
+
+  desc "指定したサーバーを再作成（削除して作成）"
+  task :recreate, [:server_name] => [:check_api_credentials] do |t, args|
+    server_name = args[:server_name]
+    
+    unless server_name
+      abort "❌ エラー: サーバー名が必要です\n" \
+            "使い方: rake server:recreate[coderdojo-japan]"
+    end
+    
+    puts "="*60
+    puts "🔄 DojoPaaS サーバー再作成"
+    puts "="*60
+    puts ""
+    
+    # 1. まず既存サーバーを検索
+    puts "📍 ステップ1: 既存サーバーの検索"
+    require_relative 'scripts/deploy'
+    require_relative 'scripts/sakura_server_user_agent'
+    
+    # 初期化パラメータとAPIクライアントのセットアップ
+    cli = CoderDojoSakuraCLI.new([])
+    request_params = cli.send(:perform_init_params)
+    ssua = SakuraServerUserAgent.new(**request_params)
+    
+    # 既存サーバーを検索
+    servers = ssua.get_servers()['Servers']
+    existing_server = servers.find { |s| s['Name'] == server_name }
+    
+    if existing_server
+      ip_address = existing_server['Interfaces'].first['IPAddress']
+      puts "  ✅ 既存サーバーが見つかりました"
+      puts "     - サーバー名: #{server_name}"
+      puts "     - IPアドレス: #{ip_address}"
+      puts ""
+      
+      # 2. サーバー削除
+      puts "📍 ステップ2: サーバーの削除"
+      puts "  削除実行のため、rake server:execute_deletion を使用してください:"
+      puts "  rake \"server:execute_deletion[#{ip_address},true]\""
+      puts ""
+      puts "  削除完了後、以下のコマンドで再作成:"
+      puts "  rake \"server:create[#{server_name}]\""
+    else
+      puts "  ℹ️ サーバーが存在しません。新規作成します。"
+      puts ""
+      
+      # 3. サーバー作成
+      puts "📍 ステップ3: サーバーの新規作成"
+      success = cli.create_single_server(server_name)
+      
+      if success
+        puts "✅ 再作成完了"
+      else
+        puts "❌ 作成に失敗しました"
+        exit 1
+      end
+    end
+  end
 end
 
 # ヘルパーメソッド（将来の拡張用に保持）

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,9 @@ require 'net/http'
 require 'uri'
 require 'csv'
 
+# 表示用の定数
+SEPARATOR_WIDTH = 60  # セパレーター行の幅
+
 # Minitestタスクの定義
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -49,10 +52,10 @@ task :default => :test
 desc "利用可能なDojoPaaS管理タスクをすべて表示"
 task :default do
   puts "\n🔧 DojoPaaS 管理タスク"
-  puts "=" * 50
+  puts "=" * SEPARATOR_WIDTH
   puts "'rake -T' ですべての利用可能なタスクを確認"
   puts "'rake -D [タスク名]' で詳細な説明を表示"
-  puts "=" * 50
+  puts "=" * SEPARATOR_WIDTH
   sh "rake -T"
 end
 
@@ -127,7 +130,7 @@ namespace :server do
     
     puts "✅ 有効なIPアドレス: #{validated_ip_str}"
     puts "🔍 サーバー情報を検索中..."
-    puts "-" * 50
+    puts "-" * SEPARATOR_WIDTH
     
     # 検証済みIPでinitialize_server.rbスクリプトを実行（コマンドエコーを抑制）
     sh "ruby scripts/initialize_server.rb --find #{validated_ip_str}", verbose: false
@@ -153,7 +156,7 @@ namespace :server do
     
     puts "📋 Issue処理中: #{issue_url}"
     puts "🔍 サーバー情報を抽出中..."
-    puts "-" * 50
+    puts "-" * SEPARATOR_WIDTH
     
     sh "ruby scripts/initialize_server.rb --find #{issue_url}", verbose: false
   end
@@ -171,7 +174,7 @@ namespace :server do
     end
     
     puts "🔍 サーバー名で検索: #{name}"
-    puts "-" * 50
+    puts "-" * SEPARATOR_WIDTH
     
     sh "ruby scripts/initialize_server.rb --find #{name}", verbose: false
   end
@@ -322,7 +325,7 @@ namespace :server do
     
     puts "📋 サーバー一覧を取得中..."
     puts "データソース: #{SakuraServerUserAgent::INSTANCES_CSV_URL}"
-    puts "-" * 50
+    puts "-" * SEPARATOR_WIDTH
     
     begin
       uri = URI(SakuraServerUserAgent::INSTANCES_CSV_URL)
@@ -381,9 +384,9 @@ namespace :server do
             "注意: servers.csvに登録されているサーバー名を指定してください"
     end
     
-    puts "="*60
+    puts "="*SEPARATOR_WIDTH
     puts "🚀 DojoPaaS 個別サーバー作成"
-    puts "="*60
+    puts "="*SEPARATOR_WIDTH
     puts ""
     puts "サーバー名: #{server_name}"
     puts ""
@@ -396,9 +399,9 @@ namespace :server do
     
     if success
       puts ""
-      puts "="*60
+      puts "="*SEPARATOR_WIDTH
       puts "✅ サーバー作成プロセス完了"
-      puts "="*60
+      puts "="*SEPARATOR_WIDTH
       puts ""
       puts "【次のステップ】"
       puts "1. SSHで接続確認:"
@@ -409,9 +412,9 @@ namespace :server do
       puts ""
     else
       puts ""
-      puts "="*60
+      puts "="*SEPARATOR_WIDTH
       puts "❌ サーバー作成に失敗しました"
-      puts "="*60
+      puts "="*SEPARATOR_WIDTH
       exit 1
     end
   end
@@ -425,9 +428,9 @@ namespace :server do
             "使い方: rake server:recreate[coderdojo-japan]"
     end
     
-    puts "="*60
+    puts "="*SEPARATOR_WIDTH
     puts "🔄 DojoPaaS サーバー再作成"
-    puts "="*60
+    puts "="*SEPARATOR_WIDTH
     puts ""
     
     # 1. まず既存サーバーを検索

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -20,12 +20,5 @@ else
     COMMIT_MSG="Deploy from actions"
 fi
 
-# 追加されたサーバー情報を取得（オプション）
-NEW_SERVERS=$(git diff --cached instances.csv | grep '^+' | grep -v '^+++' | cut -d',' -f1 | sed 's/^+//' | head -3 | paste -sd ', ' || echo "")
-
-if [ -n "$NEW_SERVERS" ]; then
-    COMMIT_MSG="$COMMIT_MSG - Added: $NEW_SERVERS"
-fi
-
 git commit --quiet -m    "$COMMIT_MSG"
 git push --force --quiet "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" main:gh-pages


### PR DESCRIPTION
## 変更内容

### 1. 個別サーバー作成タスクの追加
- `rake server:create[サーバー名]` で個別にサーバーを作成可能
- `rake server:recreate[サーバー名]` で再作成をガイド
- 既存のdeploy.rbのロジックを最大限再利用（DRY原則）

### 2. コードの改善
- マジックナンバー60を定数`SEPARATOR_WIDTH`に置き換え
- 自動デプロイコミットメッセージを簡潔化（PR番号のみ）

## 使用例

```bash
# 個別サーバー作成
rake "server:create[coderdojo-japan]"

# サーバー再作成のガイド
rake "server:recreate[coderdojo-japan]"
```

## 利点
- CI/CDを通さずに即座にサーバーをテスト可能
- SSH修正などの機能テストが容易に
- 削除は手動確認を要求（安全性優先）
- サーバーがない場合の作成は冪等性あり

## 安全性の考慮
- サーバー削除は手動操作を要求（DANGER ZONE）
- 既存サーバーの検出と警告機能
- 部分的な冪等性で安全性と利便性のバランス